### PR TITLE
ecmaversion 2018

### DIFF
--- a/rules/config.js
+++ b/rules/config.js
@@ -8,6 +8,9 @@ module.exports = {
   'plugins': [
     'starry'
   ],
+  "parserOptions": {
+    "ecmaVersion": 2018
+  },
   'rules': {
     'no-undef': 2,
     'block-scoped-var': 2,


### PR DESCRIPTION
Adding this because it includes object spread/rest syntax support.

I'm not entirely sure this is the correct way this is supposed to be added to this config file. 