### PR TITLE
Bump to 8.0.0, bump eslint-plugin-starry to 6.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-starry",
-  "version": "7.2.0",
+  "version": "8.0.0",
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -16,6 +16,6 @@
   },
   "homepage": "https://github.com/StarryInternet/eslint-config-starry",
   "dependencies": {
-    "eslint-plugin-starry": "5.0.0"
+    "eslint-plugin-starry": "6.0.0"
   }
 }


### PR DESCRIPTION
Use `eslint-plugin-starry` 6.0.0 which adds autofix to the `space-in-parens` rule.