### PR TITLE
Don't allow const reassignments

### DIFF
--- a/rules/config.js
+++ b/rules/config.js
@@ -55,6 +55,7 @@ module.exports = {
     'space-unary-ops': [ 2, { 'words': true, 'nonwords': false } ],
     'prefer-const': 2,
     'prefer-arrow-callback': 2,
-    'strict': [ 2, 'never' ]
+    'strict': [ 2, 'never' ],
+    'no-const-assign': 2
   }
 };


### PR DESCRIPTION
I honestly thought ESLint enforced this automatically when `impliedStrict` was `true`. But alas, it was allowing `const` reassignment all along.

Ask me how I came to know this.

