### PR TITLE
Add node-specific rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,24 +1,25 @@
 {
   "name": "@starryinternet/eslint-config-starry",
   "version": "9.2.0",
-  "description": "",
-  "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+  "author": "Starry Internet",
+  "description": "Starry JavaScript Styleguide for ESLint",
+  "homepage": "https://github.com/StarryInternet/eslint-config-starry",
+  "bugs": {
+    "url": "https://github.com/StarryInternet/eslint-config-starry/issues"
   },
   "repository": {
     "type": "git",
     "url": "https://github.com/StarryInternet/eslint-config-starry"
   },
-  "author": "",
-  "bugs": {
-    "url": "https://github.com/StarryInternet/eslint-config-starry/issues"
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "homepage": "https://github.com/StarryInternet/eslint-config-starry",
   "dependencies": {
-    "@starryinternet/eslint-plugin-starry": "~7.3.2"
+    "@starryinternet/eslint-plugin-starry": "~7.3.8",
+    "eslint-plugin-node": "11.1.0"
   },
   "peerDependencies": {
-    "eslint": ">= 6.8.0"
+    "eslint": ">= 7.0.0"
   }
 }

--- a/rules/config.js
+++ b/rules/config.js
@@ -6,7 +6,8 @@ module.exports = {
     'es6': true
   },
   'plugins': [
-    '@starryinternet/starry'
+    '@starryinternet/starry',
+    'node'
   ],
   'parserOptions': {
     'ecmaVersion': 2019,
@@ -56,6 +57,14 @@ module.exports = {
     'prefer-const': 2,
     'prefer-arrow-callback': 2,
     'strict': [ 2, 'never' ],
-    'no-const-assign': 2
+    'no-const-assign': 2,
+
+    // Node
+    'node/no-exports-assign': 'error',
+    'node/no-extraneous-require': 'error',
+    'node/no-missing-require': 'error',
+    'node/process-exit-as-throw': 'error',
+    'node/no-deprecated-api': 'error',
+    'node/shebang': 'error'
   }
 };


### PR DESCRIPTION
Add a few node-specific rules from the newish `eslint-plugin-node`. I chose rules that should only error if there is a likely runtime error, specifically rules around imports that are extraneous/missing. I also added `process-exit-as-throw` and `no-deprecated-api` to give us some better tooling there, but neither of those will cause any errors, only warnings. 

Because this is a scoped package, it was able to use `@starryinternet/eslint-plugin-starry` because it was under the same scope. However, ESLint 6 reads configs _relative to their import location_, so ESLint 6 was unable to properly require `eslint-plugin-node`. This is fixed in ESLint 7, so I bumped the minimum ESLint version to 7. Therefore, this PR is a breaking change and will need to go out as v10.