### PR TITLE
Update ecmaVersion from 2019->2021

### DIFF
--- a/rules/config.js
+++ b/rules/config.js
@@ -10,7 +10,7 @@ module.exports = {
     'node'
   ],
   'parserOptions': {
-    'ecmaVersion': 2019,
+    'ecmaVersion': 2021,
     'ecmaFeatures': {
       'impliedStrict': true
     }


### PR DESCRIPTION
of interest to me is allowing the `??` and `?.` operators: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining, https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator

If there are reasons to not update here (and therefore everything that requires it), repos can  override the `ecmaVersion` parser option in their respective `.eslintrc` files