### PR TITLE
disallow parens on argument-less constructor

### DIFF
--- a/rules/config.js
+++ b/rules/config.js
@@ -46,6 +46,7 @@ module.exports = {
     'semi-spacing': [ 2, { 'before': false, 'after': true } ],
     'space-before-blocks': [ 2, 'always' ],
     'space-before-function-paren': [ 2, 'never' ],
+    'new-parens': [ 2, 'never' ],
     'keyword-spacing': [ 2, { 'before': true, 'after': true } ],
     '@starryinternet/starry/space-in-parens': [ 2, 'always', { 'exceptions': [ '{}', '[]', 'empty' ] } ],
     'max-len': [ 2, 80, 2 ],


### PR DESCRIPTION
This will cause `new Object()` or `new Object( )` to throw an eslint error, in favor of `new Object` or `( new Object )`.

eslint docs for this rule: https://eslint.org/docs/rules/new-parens

I tried playing around with the the `space-in-parens` exceptions: https://eslint.org/docs/8.0.0/rules/space-in-parens#empty-exception
but it seems like those specifically don't apply to constructor invocations.