### PR TITLE
Add quote-props

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,4 +2,4 @@ module.exports = {
   extends: [
     './rules/config'
   ].map( require.resolve )
-}
+};

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   },
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "eslint --config index.js .",
+    "fix": "eslint --config index.js --fix ."
   },
   "dependencies": {
     "@starryinternet/eslint-plugin-starry": "^8.0.0",

--- a/rules/config.js
+++ b/rules/config.js
@@ -60,6 +60,7 @@ module.exports = {
     'prefer-arrow-callback': 2,
     'strict': [ 2, 'never' ],
     'no-const-assign': 2,
+    'quote-props': [ 2, 'consistent-as-needed' ],
 
     // Node
     'node/no-exports-assign': 'error',

--- a/rules/config.js
+++ b/rules/config.js
@@ -1,21 +1,23 @@
+/* eslint-disable max-len */
+
 module.exports = {
-  'root': true,
-  'env': {
-    'node': true,
-    'browser': true,
-    'es6': true
+  root: true,
+  env: {
+    node: true,
+    browser: true,
+    es6: true
   },
-  'plugins': [
+  plugins: [
     '@starryinternet/starry',
     'node'
   ],
-  'parserOptions': {
-    'ecmaVersion': 2022,
-    'ecmaFeatures': {
-      'impliedStrict': true
+  parserOptions: {
+    ecmaVersion: 2022,
+    ecmaFeatures: {
+      impliedStrict: true
     }
   },
-  'rules': {
+  rules: {
     'no-undef': 2,
     'block-scoped-var': 2,
     'no-eq-null': 2,
@@ -23,37 +25,37 @@ module.exports = {
     'curly': 2,
     'no-delete-var': 2,
     'no-shadow-restricted-names': 2,
-    'no-unused-vars': [ 2, { 'ignoreRestSiblings': true } ],
+    'no-unused-vars': [ 2, { ignoreRestSiblings: true } ],
     'no-use-before-define': [ 2, 'nofunc' ],
     'no-var': 2,
     'one-var': [ 2, 'never' ],
-    'indent': [ 2, 2, { 'SwitchCase': 1, 'MemberExpression': 0 } ],
-    'quotes': [ 2, 'single', { 'allowTemplateLiterals': true } ],
+    'indent': [ 2, 2, { SwitchCase: 1, MemberExpression: 0 } ],
+    'quotes': [ 2, 'single', { allowTemplateLiterals: true } ],
     'semi': [ 2, 'always' ],
     'comma-dangle': [ 2, 'never' ],
     'array-bracket-spacing': [ 2, 'always' ],
     'block-spacing': [ 2, 'always' ],
-    'brace-style': [ 2, '1tbs', { 'allowSingleLine': true } ],
-    'comma-spacing': [ 2, { 'before': false, 'after': true } ],
+    'brace-style': [ 2, '1tbs', { allowSingleLine: true } ],
+    'comma-spacing': [ 2, { before: false, after: true } ],
     'comma-style': [ 2, 'last' ],
     '@starryinternet/starry/computed-property-spacing': [ 2, 'always' ],
     'eol-last': [ 2, 'unix' ],
-    'key-spacing': [ 2, { 'beforeColon' : false, 'afterColon': true, 'mode': 'minimum' } ],
+    'key-spacing': [ 2, { beforeColon: false, afterColon: true, mode: 'minimum' } ],
     'linebreak-style': [ 2, 'unix' ],
     'no-spaced-func': 2,
     'no-trailing-spaces': 2,
     'object-curly-spacing': [ 2, 'always' ],
-    'semi-spacing': [ 2, { 'before': false, 'after': true } ],
+    'semi-spacing': [ 2, { before: false, after: true } ],
     'space-before-blocks': [ 2, 'always' ],
     'space-before-function-paren': [ 2, 'never' ],
-    'keyword-spacing': [ 2, { 'before': true, 'after': true } ],
-    '@starryinternet/starry/space-in-parens': [ 2, 'always', { 'exceptions': [ '{}', '[]', 'empty' ] } ],
+    'keyword-spacing': [ 2, { before: true, after: true } ],
+    '@starryinternet/starry/space-in-parens': [ 2, 'always', { exceptions: [ '{}', '[]', 'empty' ] } ],
     'max-len': [ 2, 80, 2 ],
     'space-infix-ops': [ 2 ],
     '@starryinternet/starry/aligned-requires': [ 2, 'always' ],
     'object-shorthand': [ 2, 'always' ],
     'template-curly-spacing': [ 2, 'always' ],
-    'space-unary-ops': [ 2, { 'words': true, 'nonwords': false } ],
+    'space-unary-ops': [ 2, { words: true, nonwords: false } ],
     'prefer-const': 2,
     'prefer-arrow-callback': 2,
     'strict': [ 2, 'never' ],


### PR DESCRIPTION
Two changes:

1. Added linting to this repo (eating our own dog food)
2. Added a new [quote-props](https://eslint.org/docs/latest/rules/quote-props#consistent-as-needed) rule

I think [consistent-as-needed](https://eslint.org/docs/latest/rules/quote-props#consistent-as-needed) is pretty much what we've already been doing informally, so I don't see this creating huge diffs.

It's mostly just gonna be lazy fixture data that was generated via `Copy actual JSON payload > Paste > Convert to single quotes to appease the linter`. So this just goes one step further and removes quoted property keys unless the quotes are actually necessary.